### PR TITLE
Fixes to make upgrade from EKS 1.20 to 1.21 works

### DIFF
--- a/images/dataplane/nodegroup/app/nodegroup_ver_update.py
+++ b/images/dataplane/nodegroup/app/nodegroup_ver_update.py
@@ -22,6 +22,7 @@ import cfnresponse
 
 class ConfigKey:
     cluster_name_key = 'EksClusterName'
+    cluster_version_key = 'EksUpdateClusterVersion'
     node_group_key = 'EksNodeGroup'
     launch_template_name = 'EksNodeGroupTemplateName'
     launch_template_version = 'EksNodeGroupTemplateVersion'
@@ -38,6 +39,7 @@ session_name = 'EKS_UPDATE_NODE_SESSION'
 
 config_dict = {
     ConfigKey.cluster_name_key: os.environ[ConfigKey.cluster_name_key],
+    ConfigKey.cluster_version_key: os.environ[ConfigKey.cluster_version_key],
     ConfigKey.node_group_key: os.environ[ConfigKey.node_group_key],
     ConfigKey.launch_template_name: os.environ[ConfigKey.launch_template_name],
     ConfigKey.launch_template_version: os.environ[ConfigKey.launch_template_version]
@@ -61,6 +63,7 @@ def get_stdout(output):
 
 def update_cluster(config_dict):
     cluster_name = config_dict[ConfigKey.cluster_name_key]
+    cluster_version = config_dict[ConfigKey.cluster_version_key]
     node_group_name = config_dict[ConfigKey.node_group_key]
     launch_template_name = config_dict[ConfigKey.launch_template_name]
     launch_template_version = config_dict[ConfigKey.launch_template_version]
@@ -92,7 +95,9 @@ def update_cluster(config_dict):
 
     # describe nodegroup
     logger.info('run awscli to update nodegroup template version')
-    update_nodegroup_version = f'aws eks update-nodegroup-version --cluster-name {cluster_name} --nodegroup-name {node_group_name} --launch-template name={launch_template_name},version={launch_template_version}'
+    # You can update to the latest AMI version of your cluster's current Kubernetes version by specifying your cluster's Kubernetes version in the request.
+    # https://docs.aws.amazon.com/cli/latest/reference/eks/update-nodegroup-version.html
+    update_nodegroup_version = f'aws eks update-nodegroup-version  --cluster-name {cluster_name} --nodegroup-name {node_group_name} --kubernetes-version {cluster_version} --launch-template name={launch_template_name},version={launch_template_version}'
     output = subprocess.run(f'{update_nodegroup_version}', encoding='utf-8', capture_output=True, shell=True)
     command_output = get_stdout(output)
     logger.info(f'update nodegroup dataplane output: {command_output}')

--- a/images/dataplane/nodegroup/app/nodegroup_ver_update.py
+++ b/images/dataplane/nodegroup/app/nodegroup_ver_update.py
@@ -95,9 +95,11 @@ def update_cluster(config_dict):
 
     # describe nodegroup
     logger.info('run awscli to update nodegroup template version')
-    # You can update to the latest AMI version of your cluster's current Kubernetes version by specifying your cluster's Kubernetes version in the request.
-    # https://docs.aws.amazon.com/cli/latest/reference/eks/update-nodegroup-version.html
-    update_nodegroup_version = f'aws eks update-nodegroup-version  --cluster-name {cluster_name} --nodegroup-name {node_group_name} --kubernetes-version {cluster_version} --launch-template name={launch_template_name},version={launch_template_version}'
+    if cluster_version:
+        update_nodegroup_version = f'aws eks update-nodegroup-version  --cluster-name {cluster_name} --nodegroup-name {node_group_name} --kubernetes-version {cluster_version} --launch-template name={launch_template_name},version={launch_template_version}'
+    else:
+        update_nodegroup_version = f'aws eks update-nodegroup-version  --cluster-name {cluster_name} --nodegroup-name {node_group_name} --launch-template name={launch_template_name},version={launch_template_version}'
+
     output = subprocess.run(f'{update_nodegroup_version}', encoding='utf-8', capture_output=True, shell=True)
     command_output = get_stdout(output)
     logger.info(f'update nodegroup dataplane output: {command_output}')

--- a/parameters/dataplane-nodegroup.json
+++ b/parameters/dataplane-nodegroup.json
@@ -4,6 +4,10 @@
     "ParameterValue": "<INPUT_CLUSTER_NAME>"
   },
   {
+    "ParameterKey": "EksUpdateClusterVersion",
+    "ParameterValue": "<INPUT_CLUSTER_UPGRADE_VERSION>"
+  },
+  {
     "ParameterKey": "EksNodeGroup",
     "ParameterValue": "<INPUT_WORKER_NODE_NAME>"
   }, 

--- a/templates/dataplane-nodegroup.yml
+++ b/templates/dataplane-nodegroup.yml
@@ -20,6 +20,8 @@ Transform: 'AWS::Serverless-2016-10-31'
 Parameters:
   EksClusterName:
     Type: String
+  EksUpdateClusterVersion:
+    Type: String
   EksNodeGroup:
     Type: String
   EKSNodeGroupTemplateName:
@@ -56,6 +58,7 @@ Resources:
       Environment:
         Variables:
           EksClusterName: !Ref EksClusterName
+          EksUpdateClusterVersion: !Ref EksUpdateClusterVersion
           EksNodeGroupTemplateVersion: !Ref EKSNodeGroupTemplateVersion
           EksNodeGroupTemplateName: !Ref EKSNodeGroupTemplateName
           EksNodeGroup: !Ref EksNodeGroup
@@ -83,6 +86,7 @@ Resources:
           SignalUrl: !Ref WaitHandle
           UpdateID: !GetAtt EKSNodeUpdateFunction.UpdateID
           EksClusterName: !Ref EksClusterName
+          EksUpdateClusterVersion: !Ref EksUpdateClusterVersion
           EksNodeGroupTemplateVersion: !Ref EKSNodeGroupTemplateVersion
           EksNodeGroupTemplateName: !Ref EKSNodeGroupTemplateName
           EksNodeGroup: !Ref EksNodeGroup

--- a/templates/iam.yml
+++ b/templates/iam.yml
@@ -72,6 +72,11 @@ Resources:
             - !Sub 'arn:aws:eks:*:${AWS::AccountId}:cluster/*'
         - Effect: "Allow"
           Action:
+            - 'eks:DescribeAddonVersions'
+          Resource:
+            - '*'
+        - Effect: "Allow"
+          Action:
             - 'logs:CreateLogStream'
             - 'logs:DescribeLogGroups'
             - 'logs:DescribeLogStreams'


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
I tried to follow the blog https://aws.amazon.com/blogs/opensource/automate-amazon-eks-upgrades-with-infrastructure-as-code/
However, version 1.19 is no longer supported by AWS EKS. So, I use EKS version 1.20 and then trying to upgrade to 1.21.

There are few issues that I fixed 
1. kube-proxy daemonset upgrade failed  with the following error
```
[ERROR] 2022-10-29T06:07:10.007Z ad78a3eb-9840-46ec-a8c6-882bb518ed29 Command failed for - stderr: Error: failed to describe addon versions: operation error EKS: DescribeAddonVersions, https response error StatusCode: 403, RequestID: 54d3ff44-d44b-41fb-8d3c-80f707be6fec, api error AccessDeniedException: User is not authorized to perform this action
```
fixed by updating iam.yml to allow `eks:DescribeAddonVersions` 
2. after running all the steps. the nodes are not upgraded to 1.21.
After adding `--kubernetes-version` upon calling `aws eks update-nodegroup-version`, the nodes are upgraded.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
